### PR TITLE
Fix paths to temp dir / winget.exe

### DIFF
--- a/src/UniGetUI/Pages/DialogPages/DialogHelper_Generic.cs
+++ b/src/UniGetUI/Pages/DialogPages/DialogHelper_Generic.cs
@@ -321,8 +321,8 @@ public static partial class DialogHelper
                             "windowspowershell\\v1.0\\powershell.exe"),
                     Arguments =
                         "-ExecutionPolicy Bypass -NoLogo -NoProfile -Command \"& {" +
-                        "cmd.exe /C \"rmdir /Q /S `\"%localappdata%\\Temp\\WinGet`\"\"; " +
-                        "cmd.exe /C \"%localappdata%\\Microsoft\\WindowsApps\\winget.exe source reset --force\"; " +
+                        "cmd.exe /C \"rmdir /Q /S `\"%temp%\\WinGet`\"\"; " +
+                        "cmd.exe /C \"`\"%localappdata%\\Microsoft\\WindowsApps\\winget.exe`\" source reset --force\"; " +
                         "taskkill /im winget.exe /f; " +
                         "taskkill /im WindowsPackageManagerServer.exe /f; " +
                         "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force; " +


### PR DESCRIPTION
- Temp folder isn't always in `%localappdata%\Temp`
- User profile path may contain spaces

<!-- Provide a general summary of your changes in the title above -->
- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [ ] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the contributors' time, who have to spend their free time reviewing, fixing, and testing code that does not even compile breaks other features, or does not introduce any useful changes. I appreciate your understanding.
-----

On my machine, the WinGet reset feature always prints this at the beginning:

```
The system cannot find the file specified.
The system cannot find the path specified.
```

The reason is that my TEMP folder is moved to `T:\Temp` (`%tmp%` variable is set accordingly) and my user profile path has a space in it.

This should fix both issues, however:

- I did not compile UniGetUI to test the change properly.
- Even performing these steps manually, it still doesn't fix WinGet on my machine. To fix it, I have to manually remove and re-add the sources.